### PR TITLE
Updated field depedencies according to jobbsporet-361

### DIFF
--- a/force-app/main/default/objects/Work_Trail__c/fields/ips_Other_end_cases__c.field-meta.xml
+++ b/force-app/main/default/objects/Work_Trail__c/fields/ips_Other_end_cases__c.field-meta.xml
@@ -54,11 +54,6 @@
                 <label>Other (military, pregnancy, relocation, etc.)</label>
             </value>
             <value>
-                <fullName>Not applicable</fullName>
-                <default>false</default>
-                <label>Not applicable</label>
-            </value>
-            <value>
                 <fullName>Work without wage subsidy</fullName>
                 <default>false</default>
                 <label>Work without wage subsidy</label>
@@ -77,6 +72,11 @@
                 <fullName>Work in combination with a graduated disability pension</fullName>
                 <default>false</default>
                 <label>Work in combination with a graduated disability pension</label>
+            </value>
+            <value>
+                <fullName>Not applicable</fullName>
+                <default>false</default>
+                <label>Not applicable</label>
             </value>
             <value>
                 <fullName>.NA</fullName>
@@ -103,12 +103,6 @@
                 <label>NA</label>
             </value>
         </valueSetDefinition>
-        <valueSettings>
-            <controllingFieldValue>Work</controllingFieldValue>
-            <controllingFieldValue>Other end causes</controllingFieldValue>
-            <controllingFieldValue>Education</controllingFieldValue>
-            <valueName>Not applicable</valueName>
-        </valueSettings>
         <valueSettings>
             <controllingFieldValue>Work</controllingFieldValue>
             <valueName>Work without wage subsidy</valueName>
@@ -158,6 +152,10 @@
         <valueSettings>
             <controllingFieldValue>Other end causes</controllingFieldValue>
             <valueName>Other (military, pregnancy, relocation, etc.)</valueName>
+        </valueSettings>
+        <valueSettings>
+            <controllingFieldValue>Other end causes</controllingFieldValue>
+            <valueName>Not applicable</valueName>
         </valueSettings>
     </valueSet>
 </CustomField>


### PR DESCRIPTION
Removed "Not applicable" dependent picklist value from work and education. It is available only when "other end causes" is selected. 