### PR TITLE
Updated status picklist values in Task object

### DIFF
--- a/force-app/main/default/objects/Task/recordTypes/ArbeidsgiverTask.recordType-meta.xml
+++ b/force-app/main/default/objects/Task/recordTypes/ArbeidsgiverTask.recordType-meta.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RecordType xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>IPS_Task</fullName>
+    <fullName>ArbeidsgiverTask</fullName>
     <active>true</active>
-    <compactLayoutAssignment>Deloppgaver_UO</compactLayoutAssignment>
-    <label>IPS/UOTask</label>
+    <label>AG Oppgave</label>
     <picklistValues>
         <picklist>F_rste_arbeidsgiverm_te__c</picklist>
         <values>
@@ -47,6 +46,10 @@
     </picklistValues>
     <picklistValues>
         <picklist>IPS_Type__c</picklist>
+        <values>
+            <fullName>Arbeidsgivermøte</fullName>
+            <default>false</default>
+        </values>
         <values>
             <fullName>First Meeting with Employer</fullName>
             <default>false</default>
@@ -97,7 +100,19 @@
     <picklistValues>
         <picklist>Subject</picklist>
         <values>
+            <fullName>Call</fullName>
+            <default>false</default>
+        </values>
+        <values>
             <fullName>Other</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Send Letter</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Send Quote</fullName>
             <default>false</default>
         </values>
     </picklistValues>
@@ -174,14 +189,22 @@
     <picklistValues>
         <picklist>Type</picklist>
         <values>
-            <fullName>Meeting</fullName>
+            <fullName>Call</fullName>
             <default>false</default>
         </values>
     </picklistValues>
     <picklistValues>
         <picklist>Type_of_Task_IPSUO__c</picklist>
         <values>
+            <fullName>Annet</fullName>
+            <default>false</default>
+        </values>
+        <values>
             <fullName>Delmål %28av hovedmål%29</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Historikk</fullName>
             <default>false</default>
         </values>
         <values>
@@ -189,7 +212,35 @@
             <default>false</default>
         </values>
         <values>
+            <fullName>Loggfør Epost</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Loggfør Epost Arb%2Egiver</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Loggfør SMS</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Loggfør SMS Arb%2Egiver</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Loggfør Samtale Arb%2Egiver</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Loggfør samtale</fullName>
+            <default>false</default>
+        </values>
+        <values>
             <fullName>Oppgave</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Oppgave Arb%2Egiver</fullName>
             <default>false</default>
         </values>
         <values>

--- a/force-app/main/default/objects/Task/recordTypes/IPS_UO_contactlog.recordType-meta.xml
+++ b/force-app/main/default/objects/Task/recordTypes/IPS_UO_contactlog.recordType-meta.xml
@@ -96,13 +96,6 @@
         </values>
     </picklistValues>
     <picklistValues>
-        <picklist>Subject</picklist>
-        <values>
-            <fullName>%3Cfritekst%3E</fullName>
-            <default>false</default>
-        </values>
-    </picklistValues>
-    <picklistValues>
         <picklist>TAG_ActivityType__c</picklist>
         <values>
             <fullName>Forebygge sykefravær og redusere frafall</fullName>
@@ -110,6 +103,10 @@
         </values>
         <values>
             <fullName>Nedbemanne</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Prioritert IA %28Fia%29</fullName>
             <default>false</default>
         </values>
         <values>
@@ -161,6 +158,10 @@
         </values>
         <values>
             <fullName>Rekrutteringsoppdrag</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Utvikle partssamarbeid</fullName>
             <default>false</default>
         </values>
     </picklistValues>

--- a/force-app/main/default/standardValueSetTranslations/22-no.standardValueSetTranslation-meta.xml
+++ b/force-app/main/default/standardValueSetTranslations/22-no.standardValueSetTranslation-meta.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StandardValueSetTranslation xmlns="http://soap.sforce.com/2006/04/metadata"/>
+

--- a/force-app/main/default/standardValueSets/TaskStatus.standardValueSet-meta.xml
+++ b/force-app/main/default/standardValueSets/TaskStatus.standardValueSet-meta.xml
@@ -2,31 +2,21 @@
 <StandardValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <sorted>false</sorted>
     <standardValue>
-        <fullName>Not Started</fullName>
-        <default>false</default>
-        <label>Not Started</label>
-        <closed>false</closed>
-    </standardValue>
-    <standardValue>
         <fullName>Open</fullName>
-        <color>#3366FF</color>
         <default>true</default>
         <label>Open</label>
         <closed>false</closed>
     </standardValue>
     <standardValue>
         <fullName>Completed</fullName>
-        <color>#006600</color>
         <default>false</default>
         <label>Completed</label>
         <closed>true</closed>
     </standardValue>
     <standardValue>
         <fullName>Not applicable</fullName>
-        <color>#999999</color>
         <default>false</default>
         <label>Not applicable</label>
         <closed>true</closed>
     </standardValue>
 </StandardValueSet>
-


### PR DESCRIPTION
Added "Not applicable" to status picklist in Task object and defined it as "Closed".
Made "Not applicable" available to the following record types 
* AG Oppgave
* IPS/UO Task
* Kontaktlogg

