### PR TITLE
Removed meeting type from timeline

### DIFF
--- a/force-app/main/default/customMetadata/TimelineParent.IPS_Work_Trail_Event_first_arbg.md-meta.xml
+++ b/force-app/main/default/customMetadata/TimelineParent.IPS_Work_Trail_Event_first_arbg.md-meta.xml
@@ -12,7 +12,7 @@
     </values>
     <values>
         <field>CreateableObject_Checkbox__c</field>
-        <value xsi:type="xsd:boolean">true</value>
+        <value xsi:type="xsd:boolean">false</value>
     </values>
     <values>
         <field>CreateableObject_NoOverride__c</field>
@@ -24,7 +24,7 @@
     </values>
     <values>
         <field>IsMacro__c</field>
-        <value xsi:type="xsd:boolean">true</value>
+        <value xsi:type="xsd:boolean">false</value>
     </values>
     <values>
         <field>SObjectAssigneeId__c</field>

--- a/force-app/main/default/objects/Event/recordTypes/IPS_Event.recordType-meta.xml
+++ b/force-app/main/default/objects/Event/recordTypes/IPS_Event.recordType-meta.xml
@@ -3,7 +3,7 @@
     <fullName>IPS_Event</fullName>
     <active>true</active>
     <compactLayoutAssignment>IPS_UO_Event_compact_layout</compactLayoutAssignment>
-    <description>Denne posttypen brukes til møter i Jobbsporet med arbeidsgivere -  IPS</description>
+    <description>Denne posttypen brukes til møter i Jobbsporet med arbeidsgivere - IPS</description>
     <label>IPS Event</label>
     <picklistValues>
         <picklist>F_rste_arbeidsgiverm_te__c</picklist>
@@ -48,10 +48,6 @@
     </picklistValues>
     <picklistValues>
         <picklist>IPS_Type__c</picklist>
-        <values>
-            <fullName>First Meeting with Employer</fullName>
-            <default>false</default>
-        </values>
         <values>
             <fullName>Meeting with Employer</fullName>
             <default>true</default>


### PR DESCRIPTION
- Cannot create first meeting with employer in timeline
- Can access the old meetings in timeline
- Removed meeting type from the IPS Event record type, _type møte_ picklist