### PR TITLE
Validates to true when date and time are equal

### DIFF
--- a/force-app/main/default/objects/Work_Trail__c/validationRules/Days_before_first_employer_meeting.validationRule-meta.xml
+++ b/force-app/main/default/objects/Work_Trail__c/validationRules/Days_before_first_employer_meeting.validationRule-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Days_before_first_employer_meeting</fullName>
     <active>true</active>
     <description>Days before first employer meeting should be positive value.</description>
-    <errorConditionFormula>Oppstartsdato__c    &gt;=  ips_First_meeting_with_the_Employer_held__c</errorConditionFormula>
+    <errorConditionFormula>Oppstartsdato__c &gt; ips_First_meeting_with_the_Employer_held__c</errorConditionFormula>
     <errorDisplayField>ips_First_meeting_with_the_Employer_held__c</errorDisplayField>
     <errorMessage>Første møte med arbeidsgiver avholdt må være etter eller lik Oppstartsdato . Vennligst oppgi gyldige datoer.</errorMessage>
 </ValidationRule>


### PR DESCRIPTION
Last version of validation rule failed when the date and time are equal. This version accepts that date and time are equal.